### PR TITLE
Add: MCP Logs and Filter tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,49 +13,11 @@
         "zod": "^3.24.3"
       },
       "bin": {
-        "ftm": "build/index.ts"
+        "ftm": "build/index.js"
       },
       "devDependencies": {
         "@types/node": "^22.15.3",
-        "ts-node": "^10.9.2",
         "typescript": "^5.8.3"
-      }
-    },
-    "node_modules/@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-      "dev": true
-    },
-    "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
@@ -79,30 +41,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@tsconfig/node10": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
-      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
-      "dev": true
-    },
-    "node_modules/@tsconfig/node12": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true
-    },
-    "node_modules/@tsconfig/node14": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true
-    },
-    "node_modules/@tsconfig/node16": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
-      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "dev": true
-    },
     "node_modules/@types/node": {
       "version": "22.15.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.3.tgz",
@@ -125,36 +63,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/acorn": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
-      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
-      "dev": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-walk": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-      "dev": true,
-      "dependencies": {
-        "acorn": "^8.11.0"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true
     },
     "node_modules/body-parser": {
       "version": "2.2.0",
@@ -266,12 +174,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -310,15 +212,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.3.1"
       }
     },
     "node_modules/dunder-proto": {
@@ -644,12 +537,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
-    },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -1043,49 +930,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/ts-node": {
-      "version": "10.9.2",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
-      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-      "dev": true,
-      "dependencies": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-esm": "dist/bin-esm.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "peerDependencies": {
-        "@swc/core": ">=1.2.50",
-        "@swc/wasm": ">=1.2.50",
-        "@types/node": "*",
-        "typescript": ">=2.7"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/wasm": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/type-is": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
@@ -1130,12 +974,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true
-    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -1165,15 +1003,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
-    },
-    "node_modules/yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/zod": {
       "version": "3.24.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
+import checkValidHexadecimal from "./utils/type-check.js";
 
 const API_BASE_URL = "https://docs-demo.quiknode.pro"; // ETH
 // const API_BASE_URL = "https://rpc.soniclabs.com"; // SONIC
@@ -158,6 +159,7 @@ server.tool(
     }
 );
 
+// eth_getLogs tool
 server.tool(
     "get-logs",
     "Fetch logs for a contract within a given block range",
@@ -210,7 +212,7 @@ server.tool(
     }
 );
 
-
+// eth_newFilter tool
 server.tool(
     "get-new-filter",
     "Creates a log filter for tracking state changes",
@@ -255,6 +257,7 @@ server.tool(
       }
 );
 
+// eth_newBlockFilter tool
 server.tool(
     "get-new-block-filter",
     "Creates a filter to detect new block arrivals.",
@@ -287,6 +290,7 @@ server.tool(
     }
 );
 
+// eth_newPendingTransactionFilter tool
 server.tool(
     "get-new-pending-tran-filter",
     "Creates a filter to detect new pending transaction",
@@ -319,6 +323,7 @@ server.tool(
     }
 );
 
+// eth_getFilterChanges tool
 server.tool(
     "get-filter-changes",
     "Polls a filter to get new logs, block hashes, or transaction hashes since the last check.",
@@ -364,6 +369,7 @@ server.tool(
     }
   );
   
+// eth_getFilterLogs tool
   server.tool(
     "get-filter-logs",
     "Polls a filter to get all logs matching the filter ID.",
@@ -409,6 +415,7 @@ server.tool(
     }
   );
   
+// eth_uninstallFilter tool
   server.tool(
     "uninstall-filter",
     "Uninstalls a filter with the given filter ID.",
@@ -431,31 +438,22 @@ server.tool(
           ],
         };
       }
-  
-      const success = rpcResult.result;
-  
-      if (success) {
-        return {
-          content: [
-            {
-              type: "text",
-              text: `Successfully uninstalled filter ID ${filterId}.`,
-            },
-          ],
-        };
-      } else {
-        return {
-          content: [
-            {
-              type: "text",
-              text: `Failed to uninstall filter ID ${filterId}.`,
-            },
-          ],
-        };
-      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: rpcResult.result?
+                                `Successfully uninstalled filter ID ${filterId}.`
+                                :`Failed to uninstall filter ID ${filterId}.`
+          },
+        ],
+      };
+      
     }
   );
 
+// eth_submitWork tool
   server.tool(
     "submit-proof-of-work",
     "Submits a proof-of-work solution to the network.",
@@ -480,31 +478,21 @@ server.tool(
           ],
         };
       }
-  
-      const success = rpcResult.result;
-  
-      if (success) {
-        return {
-          content: [
-            {
-              type: "text",
-              text: `Successfully submitted PoW solution.`,
-            },
-          ],
-        };
-      } else {
-        return {
-          content: [
-            {
-              type: "text",
-              text: `Failed to submit PoW solution. Invalid solution.`,
-            },
-          ],
-        };
-      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: rpcResult.result?
+                                "Successfully submitted PoW solution."
+                                :"Failed to submit PoW solution. Invalid solution."
+          },
+        ],
+      };
     }
   );
   
+// web3_clientVersion tool
   server.tool(
     "get-client-version",
     "Fetches the current version of the Ethereum client.",
@@ -525,19 +513,18 @@ server.tool(
         };
       }
   
-      const version = rpcResult.result;
-  
       return {
         content: [
           {
             type: "text",
-            text: `Current Ethereum client version: ${version}`,
+            text: `Current Ethereum client version: ${rpcResult.result}`,
           },
         ],
       };
     }
   );
 
+// web3_sha3 tool
   server.tool(
     "get-sha3-hash",
     "Generates a Keccak-256 (SHA3) hash of the given hexadecimal data.",
@@ -545,8 +532,7 @@ server.tool(
       data: z.string().min(1).describe("The data in hexadecimal form to convert into a SHA3 hash"),
     },
     async ({ data }) => {
-      // Ensure the data is in valid hexadecimal format (optional, for validation)
-      if (!/^0x[0-9A-Fa-f]*$/.test(data)) {
+      if (checkValidHexadecimal(data)) {
         return {
           content: [
             {
@@ -573,13 +559,11 @@ server.tool(
         };
       }
   
-      const sha3Hash = rpcResult.result;
-  
       return {
         content: [
           {
             type: "text",
-            text: `SHA3 (Keccak-256) hash of the provided data: ${sha3Hash}`,
+            text: `SHA3 (Keccak-256) hash of the provided data: ${rpcResult.result}`,
           },
         ],
       };

--- a/src/utils/type-check.ts
+++ b/src/utils/type-check.ts
@@ -1,0 +1,6 @@
+function checkValidHexadecimal(str: string):boolean{
+    return !/^0x[0-9A-Fa-f]*$/.test(str)
+}
+
+
+export default checkValidHexadecimal;


### PR DESCRIPTION
In `index.js`

Implemented the following tools (already tested):
```
- get-logs
- get-new-filter
- get-new-block-filter
- get-new-pending-tran-filter
- get-filter-changes
- get-filter-logs
- uninstall-filter
- submit-proof-of-work
- get-client-version
- get-sha3-hash
```

Updated the makeEthRpcRequest<T> function:
- Replaced the hardcoded `id: 1` in the request body with a dynamic `id` parameter.
- The `id` parameter now defaults to `1`, allowing flexibility for tools that require different IDs (e.g., `get-new-block-filter`, `get-new-pending-tran-filter` which use 67).